### PR TITLE
Update ad_openal.c

### DIFF
--- a/src/libsphinxad/ad_openal.c
+++ b/src/libsphinxad/ad_openal.c
@@ -40,8 +40,8 @@
 
 #include "ad.h"
 
-#include <al.h>
-#include <alc.h>
+#import <OpenAL/al.h>
+#import <OpenAL/alc.h>
 
 struct ad_rec_s {
     ALCdevice * device;


### PR DESCRIPTION
fix the error occurred in Mac OS using python3 "cannot find file 'al.h'" and "cannot find file 'alc.h'"